### PR TITLE
Revert "Change primary CODEOWNER to @saic-oss/core"

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # Change me! Andrew doesn't want to be the owner of everything!
-*                           @saic-oss/core
+*                           @RothAndrew
 
 # Don't change me! Compliance team is the owner of these files
 /.github/                   @saic-oss/compliance


### PR DESCRIPTION
## what

- Reverts saic-oss/template-repo#6

## why

- Derp, this is a template repo. Codeowner needs to be whoever we want the codeowner to be when a new repo is created with this template, and since I'm the only one creating repos right now it should be me.