### PR TITLE
Add gradlew to default shellcheck excludes and add validatePreCommitH…

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,6 +30,10 @@ repos:
     rev: v0.1.10
     hooks:
       - id: shellcheck
+        exclude: |
+          (?x)^(
+            gradlew
+          )$
   - repo: https://github.com/prettier/prettier
     rev: 2.1.2
     hooks:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -3,6 +3,12 @@
 version: "2"
 
 tasks:
+  validatePreCommitHooks:
+    desc: Validate the pre-commit hooks
+    cmds:
+      - pre-commit install
+      - pre-commit run -a
+
   example:
     desc: Example to show the formatting of a task
     cmds:


### PR DESCRIPTION
…ooks to default taskfile

## what
* Start a list of excluded files in the shellcheck hook that we know always need to be excluded in various projects
* Add a `validatePreCommitHooks` task

## why
* Further reduce bootstrapping work on a new repo

## references
n/a
