### PR TITLE
Rename validate task and add missing required tasks from onboarding g…

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -3,13 +3,32 @@
 version: "2"
 
 tasks:
-  validatePreCommitHooks:
+  validate:
     desc: Validate the pre-commit hooks
     cmds:
       - pre-commit install
       - pre-commit run -a
 
-  example:
-    desc: Example to show the formatting of a task
+  test:
+    desc: Run automated tests
     cmds:
-      - echo "Peter Piper picked a peck of pickled peppers"
+      - echo "Add your logic here"
+      - exit 1
+
+  secure:
+    desc: Run automated security checks
+    cmds:
+      - echo "Add your logic here"
+      - exit 1
+
+  deliver:
+    desc: Deliver artifact
+    cmds:
+      - echo "Add your logic here"
+      - exit 1
+
+  deploy:
+    desc: Deploy project
+    cmds:
+      - echo "Add your logic here"
+      - exit 1


### PR DESCRIPTION
…uide

## what
* Rename validatePreCommitHooks task to just `validate`, to align with the new process in the onboarding guide
* Add the other required tasks from the onboarding guide that are missing. Make them fail until they are modified.

## why
- Make it as easy as possible to onboard a new repo

## references
N/A
