### PR TITLE
Fix typo and add .remarkrc to codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,5 +3,6 @@
 
 # Don't change me! Compliance team is the owner of these files
 /.github/                   @saic-oss/compliance
-/Taskfile.yaml              @saic-oss/compliance
+/Taskfile.yml               @saic-oss/compliance
 /.pre-commit-config.yaml    @saic-oss/compliance
+/.remarkrc                  @saic-oss/compliance


### PR DESCRIPTION
## what
- Fix typo in CODEOWNERS (`.yaml` -> `.yml`)
- Make @saic-oss/compliance codeowner of .remarkrc file

## why
- Would help if we actually owned the right files

## references
N/A
