### PR TITLE
Make @saic-oss/compliance the codeowner of LICENSE file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,3 +6,4 @@
 /Taskfile.yml               @saic-oss/compliance
 /.pre-commit-config.yaml    @saic-oss/compliance
 /.remarkrc                  @saic-oss/compliance
+/LICENSE                    @saic-oss/compliance


### PR DESCRIPTION
## what/why
- Make @saic-oss/compliance the codeowner of LICENSE
    - Changes to the license of any project requires admin approval
